### PR TITLE
Pin GitHub Actions to commit SHAs for supply chain security

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Run linters
         uses: PiwikPRO/actions/python/lint@master

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -9,9 +9,9 @@ jobs:
                 python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         name: Tests (Python ${{ matrix.python-version }})
         steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
           - name: Set up Python
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
             with:
                 python-version: ${{ matrix.python-version }}
                 architecture: x64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Set up Docker Buildx
         id: buildx
@@ -47,10 +47,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,9 @@ jobs:
                 python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         name: Tests (Python ${{ matrix.python-version }})
         steps:
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
           - name: Set up Python
-            uses: actions/setup-python@v2
+            uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
             with:
                 python-version: ${{ matrix.python-version }}
                 architecture: x64


### PR DESCRIPTION
## Summary
Pin external GitHub Actions from tags to commit SHAs for supply chain security.

## Changes
Replace tag references with full commit SHA hashes.

### Affected actions:
- `actions/checkout@v2`
- `actions/setup-python@v2`
- `actions/setup-python@v4`
